### PR TITLE
fix wrong campaign's map_type -> error 500

### DIFF
--- a/flask_project/campaign_manager/views.py
+++ b/flask_project/campaign_manager/views.py
@@ -695,8 +695,11 @@ def find_attribution(map_url):
     """Find map attribution."""
 
     _valid_map = valid_map_list()
-    attribution = _valid_map[map_url]
-    return attribution
+    try:
+        # map_url is not valid
+        return _valid_map[map_url]
+    except:
+        return ""
 
 
 @campaign_manager.route('/create', methods=['GET', 'POST'])


### PR DESCRIPTION
In issue #589, the campaign has been created with a wrong map_type:
![capture d ecran 2018-11-08 a 08 05 26](https://user-images.githubusercontent.com/35932320/48180637-19c25600-e32d-11e8-988c-3ce89fca1488.png)
If `map_type` isn't in the attributions list, it crashes.

It should returns nothing if it isn't present.

Fixed #589.
