### PR TITLE
Download errors/warnings as OSM file

### DIFF
--- a/lambda_functions/download/errors/aws.py
+++ b/lambda_functions/download/errors/aws.py
@@ -1,0 +1,110 @@
+import os
+import json
+import boto3
+from dependencies import yaml
+
+
+class S3Data(object):
+    """
+    Class for AWS S3
+    """
+
+    def __init__(self):
+        """
+        Initialize the s3 client.
+        """
+        self.s3 = boto3.client('s3')
+        self.bucket = os.environ['S3_BUCKET']
+
+    def fetch(self, key):
+        """
+        Fetch a S3 object from
+        :param key: path + filename
+        :type key: string
+
+        :returns: content of the file (json/yaml)
+        :rtype: dict
+        """
+        try:
+            obj = self.s3.get_object(
+                Bucket=self.bucket,
+                Key=key)
+        except:
+            print('elo')
+            return []
+
+        raw_content = obj['Body'].read()
+        return self.load(raw_content, key)
+
+    def load(self, raw_content, key):
+        """
+        Load json or yaml content.
+
+        :param raw_content: json/yaml raw_content
+        :type raw_content: bytes
+
+        :param key: path + filename
+        :type key: string
+
+        :returns: content of the file (json/yaml)
+        :rype: dict
+        """
+        if self.is_json(key):
+            return json.loads(raw_content)
+        else:
+            return yaml.load(raw_content)
+
+    def is_json(self, key):
+        """
+        Check if the key has a json/geojson extension.
+
+        :param key: path + filename
+        :type key: string
+
+        :returns: True or False
+        :rtype: boolean
+        """
+        if key.split('.')[-1] in ['json', 'geojson']:
+            return True
+        return False
+
+    def create(self, key, body):
+        """
+        Create an object in the S3 bucket.
+
+        :param key: path + filename
+        :type key: string
+
+        :param body: content of the file
+        :type body: string
+
+        :returns:
+        """
+        self.s3.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=body)
+
+    def upload_file(self, key, body):        
+        self.s3.upload_fileobj(
+            Fileobj=body, 
+            Bucket=self.bucket, 
+            Key=key,
+            ExtraArgs={
+                'ACL': 'public-read'
+            })
+
+    def download_file(self, key, feature, destination):
+        with open('/{destination}/{feature}.json'.format(
+            feature=feature,
+            destination=destination), 'wb') as data:
+                self.s3.download_fileobj(
+                    Bucket=self.bucket, 
+                    Key=key, 
+                    Fileobj=data)
+
+    def get_last_modified_date(self, key):
+        obj = self.s3.get_object(
+            Bucket=self.bucket,
+            Key=key)
+        return obj['LastModified']

--- a/lambda_functions/download/errors/lambda_function.py
+++ b/lambda_functions/download/errors/lambda_function.py
@@ -1,0 +1,28 @@
+import sys
+sys.path.insert(0, "dependencies")
+import json
+from utilities import (
+    build_query,
+    save_to_s3,
+    post_request,
+    build_path
+)
+import logging
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def lambda_handler(event, context):
+    logger.info('got event{}'.format(event))
+    uuid = event['campaign_uuid']
+    feature = event['feature']
+    
+
+    
+    query = build_query(uuid, feature);
+    post_request(query, feature)
+    save_to_s3(
+        path=build_path(uuid, feature),
+        feature=feature)
+

--- a/lambda_functions/download/errors/requirements.txt
+++ b/lambda_functions/download/errors/requirements.txt
@@ -1,0 +1,5 @@
+pyyaml==3.13
+Shapely==1.6.4.post2
+requests==2.19.1
+urllib3==1.23
+

--- a/lambda_functions/download/errors/test.py
+++ b/lambda_functions/download/errors/test.py
@@ -1,0 +1,76 @@
+import os
+import warnings
+import unittest
+from lambda_function import (
+    lambda_handler
+)
+# from utilities import
+
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        warnings.filterwarnings(
+            "ignore",
+            category=ResourceWarning,
+            message="unclosed.*<ssl.SSLSocket.*>")
+
+    def test_run(self):
+        event = {
+           'campaign_uuid': '63a268b9ea48400fb2c16acf242f75d6', 
+           'feature': 'restaurant'
+        }
+        lambda_handler(event, {})
+
+    
+
+    def test_date_to_dict(self):
+        start_date = '2018-08-01'
+        end_date = '2018-08-31'
+        date = date_to_dict(start_date, end_date)
+        self.assertEqual(date, {'from': '2018-08-01', 'to': '2018-08-31'})
+
+    def test_format_query_no_value(self):
+        formatted_value = format_feature_values([])
+        parameters = {
+            'polygon': 'polypolygon',
+            'print_mode': 'meta',
+            'key': 'amenity',
+            'value': formatted_value
+        }
+        query = format_query(parameters)
+        self.assertEqual(
+            query, '[out:json];(way["amenity"]' +
+            '(poly:"polypolygon");node["amenity"](poly:"polypolygon");' +
+            'relation["amenity"](poly:"polypolygon"););(._;>;);out meta;')
+
+    def test_format_query_with_value(self):
+        formatted_value = format_feature_values(['cafe'])
+        parameters = {
+            'polygon': 'polypolygon',
+            'print_mode': 'meta',
+            'key': 'amenity',
+            'value': formatted_value
+        }
+        query = format_query(parameters)
+        self.assertEqual(
+            query, '[out:json];(way["amenity"~"cafe"](poly:"polypolygon");' +
+            'node["amenity"~"cafe"](poly:"polypolygon");relation' +
+            '["amenity"~"cafe"](poly:"polypolygon"););(._;>;);out meta;')
+
+    def test_format_query_with_values(self):
+        formatted_value = format_feature_values(['cafe', 'coffee'])
+        parameters = {
+            'polygon': 'polypolygon',
+            'print_mode': 'meta',
+            'key': 'amenity',
+            'value': formatted_value
+        }
+        query = format_query(parameters)
+        self.assertEqual(
+            query, '[out:json];(way["amenity"~"cafe|coffee"](poly:"' +
+            'polypolygon");node["amenity"~"cafe|coffee"](poly:"polypolygon")' +
+            ';relation["amenity"~"cafe|coffee"](poly:"polypolygon"););' +
+            '(._;>;);out meta;')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda_functions/download/errors/utilities.py
+++ b/lambda_functions/download/errors/utilities.py
@@ -12,7 +12,6 @@ def get_error_ids(uuid, feature):
 
 def download_feature_completeness_file(uuid, feature):
     feature_completeness_data_path = build_feature_completeness_path(campaign_path(uuid), feature)
-    print(feature_completeness_data_path)
     return S3Data().fetch(feature_completeness_data_path)
 
 
@@ -100,7 +99,7 @@ def save_to_s3(path, feature):
 def build_path(uuid, feature):
     return '/'.join([
         'campaigns/{uuid}',
-        'render/{feature}/errors.osm'
+        'render/{feature}/{uuid}_{feature}_errors.osm'
         ]).format(
             uuid=uuid,
             feature=feature)

--- a/lambda_functions/download/errors/utilities.py
+++ b/lambda_functions/download/errors/utilities.py
@@ -1,0 +1,106 @@
+import os
+import json
+import boto3
+from dependencies import requests
+from aws import S3Data
+
+
+def get_error_ids(uuid, feature):
+    data = download_feature_completeness_file(uuid, feature)
+    return cast_element_ids_to_s(data['error_ids'])
+
+
+def download_feature_completeness_file(uuid, feature):
+    feature_completeness_data_path = build_feature_completeness_path(campaign_path(uuid), feature)
+    print(feature_completeness_data_path)
+    return S3Data().fetch(feature_completeness_data_path)
+
+
+def cast_element_ids_to_s(hash_element_ids):
+    """
+    Cast a hash of element ids to a string of element ids.
+
+    :param hash_element_ids: node/relation/way ids
+    :type hash_element_ids: hash
+
+    :returns: a string of node/relation/way ids
+    :rtype: str
+    """
+    elements_to_s = str()
+    for el in ['node', 'relation', 'way']:
+        if len(hash_element_ids[el]) > 0:
+            el_to_s = '{}(id:{});'.format(
+                el,
+                ','.join(str(element)
+                         for element in hash_element_ids[el]))
+            elements_to_s += el_to_s
+    return elements_to_s
+
+
+def build_feature_completeness_path(campaign_path, feature):
+    return '/'.join([
+        '{campaign_path}',
+        'render',
+        '{feature}',
+        'feature_completeness.json']).format(
+            campaign_path=campaign_path,
+            feature=feature)
+
+
+def campaign_path(uuid):
+    return '/'.join([
+        'campaigns',
+        '{uuid}']).format(
+            uuid=uuid)
+
+
+def format_query(parameters):
+    return (
+        '('
+        '{element_parameters}'
+        ');'
+        '(._;>;);'
+        'out {print_mode};'
+    ).format(**parameters)
+
+
+def build_query(uuid, feature):
+    error_ids = get_error_ids(uuid, feature);
+    parameters = {
+        'element_parameters': error_ids,
+        'print_mode': 'meta'
+    }
+
+    return format_query(parameters)    
+
+
+
+def post_request(query, feature):
+    data = requests.post(
+        url='http://exports-prod.hotosm.org:6080/api/interpreter',
+        data={'data': query},
+        headers={'User-Agent': 'HotOSM'},
+        stream=True)
+
+    f = open('/tmp/{}.xml'.format(feature), 'w')
+    for line in data.iter_lines():
+        if line:
+            decoded_line = line.decode('utf-8')
+            f.write(decoded_line)
+    f.close()
+
+
+def save_to_s3(path, feature):
+    with open('/tmp/{feature}.xml'.format(
+        feature=feature), 'rb') as data:
+        S3Data().upload_file(
+            key=path,
+            body=data)
+
+def build_path(uuid, feature):
+    return '/'.join([
+        'campaigns/{uuid}',
+        'render/{feature}/errors.osm'
+        ]).format(
+            uuid=uuid,
+            feature=feature)

--- a/lambda_functions/process/feature_attribute_completeness/lambda_function.py
+++ b/lambda_functions/process/feature_attribute_completeness/lambda_function.py
@@ -10,9 +10,10 @@ from utilities import (
     fetch_required_tags,
     build_render_data_path,
     invoke_render_feature,
+    invoke_download_errors,
     compute_completeness_pct,
     save_data,
-    download_overpass_file
+    download_overpass_file,
 )
 from parser import FeatureCompletenessParser
 from aws import S3Data
@@ -59,7 +60,9 @@ def lambda_handler(event, context):
         'features_completed': parser.features_completed,
         'checked_attributes': list(required_tags.keys()),
         'geojson_files_count': parser.geojson_file_manager.count,
-        'errors_files_count': parser.errors_file_manager.count
+        'errors_files_count': parser.errors_file_manager.count,
+        'error_ids': parser.error_ids
     }
     save_data(uuid, type_id, processed_data)
+    invoke_download_errors(uuid, feature)
     invoke_render_feature(uuid, feature)

--- a/lambda_functions/process/feature_attribute_completeness/parser.py
+++ b/lambda_functions/process/feature_attribute_completeness/parser.py
@@ -25,6 +25,12 @@ class FeatureCompletenessParser(xml.sax.ContentHandler):
             destination=render_data_path)
         self.errors_file_manager = ErrorsFileManager(
             destination=render_data_path)
+        self.error_ids = {
+            'node': [],
+            'way': [],
+            'relation': []
+
+        }
 
     def startDocument(self):
         return
@@ -68,6 +74,8 @@ class FeatureCompletenessParser(xml.sax.ContentHandler):
                 self.check_warnings_in_tags()
                 if self.element_complete:
                     self.features_completed += 1
+                else:
+                    self.error_ids[name].append(self.element['id'])
 
         if name == 'node':
             if self.has_tags == True:            

--- a/lambda_functions/process/feature_attribute_completeness/utilities.py
+++ b/lambda_functions/process/feature_attribute_completeness/utilities.py
@@ -15,6 +15,23 @@ def download_overpass_file(uuid, feature):
         destination='/tmp')
 
 
+def invoke_download_errors(uuid, feature):
+    payload = json.dumps({
+        'campaign_uuid': uuid,
+        'feature': feature
+    })
+
+    aws_lambda = boto3.client('lambda')
+    function_name_with_env = '{env}_{function_name}'.format(
+        env=os.environ['ENV'],
+        function_name='download_errors')
+
+    aws_lambda.invoke(
+        FunctionName=function_name_with_env,
+        InvocationType='Event',
+        Payload=payload)
+
+
 def invoke_render_feature(uuid, feature):
     payload = json.dumps({
         'campaign_uuid': uuid,

--- a/lambda_functions/render/feature/templates/errors.html
+++ b/lambda_functions/render/feature/templates/errors.html
@@ -20,7 +20,8 @@
         <li class='next-page'><a data-target="#">Next</a></li>
       </ul>
     </nav>
-  </div>  
+  </div>
+  <a href="{{ url }}/errors.osm" class="btn" style="background:#fc6525; color:white">Download</a>
 </div>
 <script type="text/javascript">
   function renderErrorsWarnings() {


### PR DESCRIPTION
This OSM file is generated into a new Lambda function: download_errors.
This function is invoked from the process_feature_attribute_completeness function.

![hot-download-errors](https://user-images.githubusercontent.com/35932320/48210439-fd033e00-e37f-11e8-9eb4-8042c006f9de.gif)


Fixed #553.

Lambda functions to update:
* process_feature_attribute_completeness
* render_feature

Lambda function to create:
* download_errors