### PR TITLE
Catch errors in lambda functions.

### DIFF
--- a/flask_project/campaign_manager/templates/campaign_detail.html
+++ b/flask_project/campaign_manager/templates/campaign_detail.html
@@ -131,6 +131,16 @@
             </div>
         </div>
     </div>
+    <div class='row' id='campaign-failure' style="display:none">
+        <div class='col-lg-12'>
+            <div class='alert alert-danger'>
+                <p>
+                    function: <b><span id="campaign-failure-function"></span></b><br />
+                    error: <b><span id="campaign-failure-error"></span></b>
+                </p>
+            </div>
+        </div>
+    </div>    
     <div class='row' id="campaign-feature-details" style="display:none">
         <div class='col-lg-12'>
             <div class="panel panel-default detail-panel-information">
@@ -288,23 +298,34 @@
         var s3CampaignUrl = '{{ s3_campaign_url | safe }}';
         var types = {{ types|safe }};
 
-        window.setTimeout(loadMapperEngagement(types, s3CampaignUrl), 200);
-        countFeaturesCollected(types, s3CampaignUrl);
-        var activeType = types[0];
-        $('.active-type').html(activeType);
-      
-        loadType(activeType, s3CampaignUrl);
-        
-      
-        $('.feature-select a').on('click', function(e) {
-            e.stopPropagation();
-            activeType = $(this).html();
-
+        $.get({
+            url: s3CampaignUrl + '/failure.json',
+            cache: false
+        }).done(function(data) {
+            $('#campaign-computing-status').hide();
+            $('#campaign-failure').show();
+            data = JSON.parse(data);
+            $('#campaign-failure-function').html(data["function"])
+            $('#campaign-failure-error').html(data["failure"])
+        }).fail(function() {
+            window.setTimeout(loadMapperEngagement(types, s3CampaignUrl), 200);
+            countFeaturesCollected(types, s3CampaignUrl);
+            var activeType = types[0];
             $('.active-type').html(activeType);
-            $('.dropdown-toggle').attr('aria-expanded', false);
-            $('.feature-select').removeClass('open');
-
+          
             loadType(activeType, s3CampaignUrl);
+            
+          
+            $('.feature-select a').on('click', function(e) {
+                e.stopPropagation();
+                activeType = $(this).html();
+
+                $('.active-type').html(activeType);
+                $('.dropdown-toggle').attr('aria-expanded', false);
+                $('.feature-select').removeClass('open');
+
+                loadType(activeType, s3CampaignUrl);
+            });
         });
         $('#download_div').hide();
     }

--- a/lambda_functions/compute/campaign/aws.py
+++ b/lambda_functions/compute/campaign/aws.py
@@ -49,6 +49,24 @@ class S3Data(object):
         except KeyError:
             return []
 
+    def create(self, key, body):
+        """
+        Create an object in the S3 bucket.
+
+        :param key: path + filename
+        :type key: string
+
+        :param body: content of the file
+        :type body: string
+
+        :returns:
+        """
+        self.s3.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=body,
+            ACL='public-read')
+
     def delete(self, key):
         """
         Delete a key in the S3 bucket.

--- a/lambda_functions/compute/campaign/lambda_function.py
+++ b/lambda_functions/compute/campaign/lambda_function.py
@@ -2,7 +2,7 @@ import boto3
 import json
 import os
 from aws import S3Data
-
+import sys
 
 def invoke_download_features(payload):
     aws_lambda = boto3.client('lambda')
@@ -37,8 +37,19 @@ def remove_data(uuid):
                 file=file)
             S3Data().delete(file_key)
 
+    S3Data().delete(f'campaigns/{uuid}/failure.json')
+
+
 
 def lambda_handler(event, context):
+    try:
+        main(event, context)
+    except Exception as e:
+        S3Data().create(
+            key=f'campaigns/{event["campaign_uuid"]}/failure.json',
+            body=json.dumps({'function': 'compute_campaign', 'failure': str(e)}))
+
+def main(event, context):
     uuid = event['campaign_uuid']
     payload = json.dumps({'campaign_uuid': uuid})
     

--- a/lambda_functions/download/errors/lambda_function.py
+++ b/lambda_functions/download/errors/lambda_function.py
@@ -10,12 +10,21 @@ from utilities import (
     campaign_path
 )
 import logging
+from aws import S3Data
 
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
+    try:
+        main(event, context)
+    except Exception as e:
+        S3Data().create(
+            key=f'campaigns/{event["campaign_uuid"]}/failure.json',
+            body=json.dumps({'function': 'download_errors', 'failure': str(e)}))
+
+def main(event, context):
     logger.info('got event{}'.format(event))
     uuid = event['campaign_uuid']
     type_name = event['type']

--- a/lambda_functions/download/features/lambda_function.py
+++ b/lambda_functions/download/features/lambda_function.py
@@ -6,14 +6,21 @@ from utilities import (
     get_unique_features,
     invoke_download_overpass_data
 )
+from aws import S3Data
 
 
 def lambda_handler(event, context):
+    try:
+        main(event, context)
+    except Exception as e:
+        S3Data().create(
+            key=f'campaigns/{event["campaign_uuid"]}/failure.json',
+            body=json.dumps({'function': 'download_features', 'failure': str(e)}))
+
+
+def main(event, context):
     uuid = event['campaign_uuid']
-    print(uuid)
     campaign = Campaign(uuid)
-    # features = get_unique_features(
-    #     functions=campaign._content_json['selected_functions'])
 
     for type_key in campaign.types:
         payload = json.dumps({
@@ -21,9 +28,3 @@ def lambda_handler(event, context):
             'type': campaign.types[type_key]['type']
         })
         invoke_download_overpass_data(payload)
-    # for feature in features:
-    #     payload = json.dumps({
-    #         'campaign_uuid': uuid,
-    #         'feature': feature
-    #     })
-    #     invoke_download_overpass_data(payload)

--- a/lambda_functions/download/overpass_data/lambda_function.py
+++ b/lambda_functions/download/overpass_data/lambda_function.py
@@ -16,15 +16,23 @@ from utilities import (
     clean_aoi
 )
 import logging
-import os
-import xml.etree.cElementTree as ET
-from dependencies.shapely import geometry
+from aws import S3Data
 
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 def lambda_handler(event, context):
+    try:
+        main(event, context)
+    except Exception as e:
+        S3Data().create(
+            key=f'campaigns/{event["campaign_uuid"]}/failure.json',
+            body=json.dumps({'function': 'download_overpass_data', 'failure': str(e)}))
+
+
+def main(event, context):
     logger.info('got event{}'.format(event))
     uuid = event['campaign_uuid']
     type_name = event['type']

--- a/lambda_functions/process/count_feature/lambda_function.py
+++ b/lambda_functions/process/count_feature/lambda_function.py
@@ -11,12 +11,21 @@ from utilities import (
     save_data
 )
 from parser import CountFeatureParser
+from aws import S3Data
 
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
+    try:
+        main(event, context)
+    except Exception as e:
+        S3Data().create(
+            key=f'campaigns/{event["campaign_uuid"]}/failure.json',
+            body=json.dumps({'function': 'process_count_feature', 'failure': str(e)}))
+
+def main(event, context):
     logger.info('got event{}'.format(event))
     uuid = event['campaign_uuid']
     type_name = event['type']

--- a/lambda_functions/process/feature_attribute_completeness/lambda_function.py
+++ b/lambda_functions/process/feature_attribute_completeness/lambda_function.py
@@ -24,6 +24,15 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
+    try:
+        main(event, context)
+    except Exception as e:
+        S3Data().create(
+            key=f'campaigns/{event["campaign_uuid"]}/failure.json',
+            body=json.dumps({'function': 'process_feature_attribute_completeness', 'failure': str(e)}))
+
+
+def main(event, context):
     logger.info('got event{}'.format(event))
     uuid = event['campaign_uuid']
     type_name = event['type']

--- a/lambda_functions/process/feature_attribute_completeness/test.py
+++ b/lambda_functions/process/feature_attribute_completeness/test.py
@@ -83,8 +83,8 @@ class TestCase(unittest.TestCase):
   
     def test_run(self):
         event = {
-           'campaign_uuid': '3a656ded5dc94f7f8f50a89d2d356a73', 
-           'type': 'RELIGION'
+           'campaign_uuid': '281ccea8628a43febda42caf30bbd316', 
+           'type': 'buildings'
         }
         lambda_handler(event, {})
 

--- a/lambda_functions/process/mapper_engagement/lambda_function.py
+++ b/lambda_functions/process/mapper_engagement/lambda_function.py
@@ -15,6 +15,15 @@ from aws import S3Data
 
 
 def lambda_handler(event, context):
+    try:
+        main(event, context)
+    except Exception as e:
+        S3Data().create(
+            key=f'campaigns/{event["campaign_uuid"]}/failure.json',
+            body=json.dumps({'function': 'process_mapper_engagement', 'failure': str(e)}))
+
+
+def main(event, context):
     uuid = event['campaign_uuid']
     type_name = event['type']
     type_id = type_name.replace(' ', '_')

--- a/lambda_functions/render/feature/lambda_function.py
+++ b/lambda_functions/render/feature/lambda_function.py
@@ -22,6 +22,15 @@ logger.setLevel(logging.INFO)
 
 
 def lambda_handler(event, context):
+    try:
+        main(event, context)
+    except Exception as e:
+        S3Data().create(
+            key=f'campaigns/{event["campaign_uuid"]}/failure.json',
+            body=json.dumps({'function': 'render_feature', 'failure': str(e)}))
+
+
+def main(event, context):
     logger.info('got event{}'.format(event))
     uuid = event['campaign_uuid']
     type_name = event['type']


### PR DESCRIPTION
I added a `try/except` in every lambda functions to catch errors that might crash the computation of a campaign.
The error is then stored in `failure.json` and displayed on the campaign page.

Fixed #558 