### PR TITLE
Patch for nodes with tags belonging to ways.

### DIFF
--- a/lambda_functions/process/feature_attribute_completeness/test.py
+++ b/lambda_functions/process/feature_attribute_completeness/test.py
@@ -83,8 +83,8 @@ class TestCase(unittest.TestCase):
   
     def test_run(self):
         event = {
-           'campaign_uuid': '3a656ded5dc94f7f8f50a89d2d356a73', 
-           'type': 'RELIGION'
+           'campaign_uuid': 'dd7b3627dc6942dc9798ea094f8c680b', 
+           'type': 'Building'
         }
         lambda_handler(event, {})
 


### PR DESCRIPTION
Fixed #611 

The reason why the map only showed half of the features is because nodes inside ways had tags (only one, the `source`).
A node with tags is a node to render on the map. 
Those nodes weren't rendered as node because they didn't have any required tags. Because they contained a tag, they were no more available to build polygons for the `way`s.

I fixed this issue by processing nodes only at the end of the file. If a node belongs to a way, it won't be processed at the end of the file. Only nodes to be rendered remain.

<img width="660" alt="screen shot 2019-01-09 at 17 39 04" src="https://user-images.githubusercontent.com/35932320/50910720-1172be00-1437-11e9-8d0e-258e0e446ad5.png">