### PR TITLE
Added the region argument to the list-functions AWS command.

### DIFF
--- a/.travis/deploy_lambda_functions.py
+++ b/.travis/deploy_lambda_functions.py
@@ -5,7 +5,7 @@ import subprocess
 CONFIG = {
     'local': {
         'env': {
-            's3_bucket': 'fieldcampaigner-data',
+            's3_bucket': 'pat-mapcampaigner-dev',
             'env': 'local'
         },
         'role': 'arn:aws:iam::142767531394:role/lambda_field_campaigner'
@@ -172,7 +172,7 @@ def create_function(path, function_name):
 
 
 def get_lambda_functions_on_aws():
-    p = subprocess.Popen('aws lambda list-functions', 
+    p = subprocess.Popen('aws lambda list-functions --region us-west-2', 
         shell=True, 
         stdout=subprocess.PIPE, 
         stderr=subprocess.STDOUT)


### PR DESCRIPTION
Without the region, the following command `aws lambda list-functions` would return nothing.
Adding the region argument `--region us-west-2` seems to fix this problem.

Fixed #501 