### PR TITLE
Fix thumbnails generation

### DIFF
--- a/deployment/docker/requirements.txt
+++ b/deployment/docker/requirements.txt
@@ -14,3 +14,4 @@ numpy
 Flask-Script
 simplekml==1.3.0
 boto3
+visvalingamwyatt==0.1.2

--- a/flask_project/campaign_manager/test/test_thumbnail.py
+++ b/flask_project/campaign_manager/test/test_thumbnail.py
@@ -1,0 +1,28 @@
+import os
+import json
+from unittest import TestCase
+from campaign_manager.aws import S3Data
+import requests
+from campaign_manager.models.campaign import Campaign
+
+
+# get the MAPBOX_TOKEN from AWS Beanstalk settings.
+MAPBOX_TOKEN = ''
+
+
+# cd flask_project/campaign_manager/test
+# nosetests campaign_manager.test.test_thumbnail
+class TestGenerateThumbnail(TestCase):
+    def setUp(self):
+        # set APP_SETTINGS to 'app_config.AWSProductionConfig'
+        # if you want to fetch a campaign in production
+        os.environ['APP_SETTINGS'] = 'app_config.AWSStagingConfig'
+        os.environ['MAPBOX_TOKEN'] = MAPBOX_TOKEN
+
+    def runTest(self):
+        campaign = Campaign('')
+        url = campaign.generate_static_map_url(simplify=False)
+        print(url)
+
+        request = requests.get(url, stream=True)
+        self.assertEqual(request.status_code, 200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ tempora==1.13
 urllib3==1.23
 Werkzeug==0.14.1
 WTForms==2.2.1
+visvalingamwyatt==0.1.2


### PR DESCRIPTION
Fixed #592 

3 campaigns had their thumbnails not generated. I found out two reasons:
- campaign's geojson were too big, more than 20000 characters. MapBox API would return `BAD URL`.
- campaign's geojson had `properties` and somehow that would cause MapBox to fail at parsing the geojson.

I used [this library](https://github.com/fitnr/visvalingamwyatt) to simplify the polygons.
