### PR TITLE
Fixes for Maps.me kml download

### DIFF
--- a/flask_project/campaign_manager/templates/campaign_detail.html
+++ b/flask_project/campaign_manager/templates/campaign_detail.html
@@ -103,7 +103,7 @@
                         </p>
                     </div>
                 </div>
-                <div class="col-lg-2 detail-button-wrapper participate-button" style="margin-top: 20px">
+                <div class="col-lg-10 detail-button-wrapper participate-button" style="margin-top: 20px">
                     <span class="btn btn-label"><strong>Participate</strong></span>
                     <div class="btn-group btn-share-group" role="group" aria-label="...">
                         {% if link_to_omk %}
@@ -112,10 +112,7 @@
                         <button type="button" id="btn-mapsme-link" class="btn btn-default" onclick="openOtherDataCollectonForm('Maps.me')"><i class="fa fa-mobile" aria-hidden="true"></i> Maps.me</button>
                     </div>
                 </div>
-                <div id="download_div" class="col-lg-4 alert alert-success">
-                    <p>Your Maps.me file is ready to download. Click <a id="download_kml" href="#">Here</a></p>
-                </div>
-                <div class="col-lg-6 detail-button-wrapper" style="margin-top: 25px;">
+                <div class="col-lg-2 detail-button-wrapper" style="margin-top: 25px;">
                     <div class="btn-group btn-share-group" role="group" aria-label="..." style="float: right;">
                         <span class="btn btn-default unclickable" >Share</span>
                         <button type="button" class="btn btn-default" onclick="shareTweet('{{ uuid }}')"> <i class="fa fa-twitter" aria-hidden="true"></i> </button>
@@ -123,6 +120,7 @@
                     </div>
                 </div>
             </div>
+            <div id="download_div" class="col-lg-12 alert"></div>
         </div>
     </div>
 
@@ -424,9 +422,13 @@
 
             success: function (kml_data) {
                 //$('#download_div').show()
-                let url = '/download_kml/'+campaign_data.uuid+'/' + kml_data.file_name
-                $('#download_kml').attr('href', url)
+                let url = '/download_kml/'+campaign_data.uuid+'/' + kml_data.file_name;
+                $('#download_div').html('Your Maps.me file is downloading. If not, click <a id="download_kml" href="' + url + '">Here</a>');
+                $('#download_div').addClass('alert-success').show();
                 $('#download_kml').get(0).click();
+            },
+            error: function (xhr, ajaxOptions, thrownError) {
+                $('#download_div').html('Error. Please contact MapCampaigner administrator').addClass('alert-danger').show();
             }
         });
 

--- a/flask_project/campaign_manager/views.py
+++ b/flask_project/campaign_manager/views.py
@@ -50,6 +50,8 @@ from reporter import LOGGER
 from reporter.static_files import static_file
 from campaign_manager.aws import S3Data
 
+from xml.sax.saxutils import escape
+
 try:
     from secret import OAUTH_CONSUMER_KEY, OAUTH_SECRET
 except ImportError:
@@ -554,7 +556,8 @@ def generate_kml():
         elif 'amenity' in tags.keys():
             kml_name = tags['amenity']
 
-        [extended_data.newdata(k, v) for k, v in tags.items() if k != 'name']
+        [extended_data.newdata(k, escape(v))
+            for k, v in tags.items() if k != 'name']
         kml.newpoint(
             name=kml_name,
             extendeddata=extended_data,


### PR DESCRIPTION
This PR contains two fixes related to the Maps.me button download:

1. It escapes not valid characters for the kml file generation. Data might have characters which are considered illegal for the kml library.
2. In the campaign detail page, two alerts are created when the kml file is created successfully or not. Please check figures below

![image](https://user-images.githubusercontent.com/3285923/52748721-41bcf780-2fb5-11e9-9799-e3aec9daddac.png)

![image](https://user-images.githubusercontent.com/3285923/52748759-5c8f6c00-2fb5-11e9-914c-e6d6f5413ea7.png)
