### PR TITLE
Use a cache directory to store campaign data

### DIFF
--- a/flask_project/campaign_manager/aws.py
+++ b/flask_project/campaign_manager/aws.py
@@ -111,9 +111,16 @@ class S3Data(object):
                 Bucket=self.bucket,
                 Prefix=prefix)['Contents']:
                 if obj['Key'] != prefix:
-                    key = obj['Key'].replace(prefix, '')
-                    objects.append(key.split('/')[0])
-            return list(set(objects))
+                    key = obj['Key'].replace(prefix, '').split('/')[0]
+                    if key in [obj['uuid'] for obj in objects]:
+                        continue
+                    modified = obj['LastModified'].toordinal()
+
+                    # Include also last_modified to check cache.
+                    data_dict = {'uuid': key, 'modified': modified}
+                    objects.append(data_dict)
+
+            return objects
         except KeyError:
             return []
 

--- a/flask_project/campaign_manager/templates/index.html
+++ b/flask_project/campaign_manager/templates/index.html
@@ -624,27 +624,17 @@
 
             $.ajax({
                 url: "/campaigns",
-                success: function(response) {
-                    const campaignRequests = buildRequests(response, bucketUrl, 'campaign.json');
-
-                    $.when.apply($, campaignRequests).then(function(){
-                        if (campaignRequests.length === 1) {
-                            var campaign = arguments[0];
-                            addCampaign(campaign, user);
-                            fetchGeometry(campaign, bucketUrl);
-                        } else {
-                            for (var i = 0; i < arguments.length; i++) {
-                                var campaign = arguments[i][0];
-                                addCampaign(campaign, user);
-                                fetchGeometry(campaign, bucketUrl);
-                            }
-                        }
-                        totalActiveCampaigns = $('.active-campaign').length;
-                        $('#active-campaign-number').html(totalActiveCampaigns);
-                        $('.inactive-campaign').hide();
-                        hideLoading();
-                        setSearch();
+                success: function(data) {
+                    data.map(function(campaign){
+                        addCampaign(campaign, user);
+                        setMarkerToMap(campaign, campaign.geojson);
                     });
+
+                    totalActiveCampaigns = $('.active-campaign').length;
+                    $('#active-campaign-number').html(totalActiveCampaigns);
+                    $('.inactive-campaign').hide();
+                    hideLoading();
+                    setSearch();
                 }
             });
 

--- a/flask_project/campaign_manager/utilities.py
+++ b/flask_project/campaign_manager/utilities.py
@@ -22,6 +22,8 @@ from reporter.exceptions import (
 from campaign_manager.aws import S3Data
 from campaign_manager.models.survey import Survey
 
+from glob import glob
+
 
 def module_path(*args):
     """Get an absolute path for a file that is relative to the root.
@@ -274,3 +276,50 @@ def get_coordinate_from_ip():
     response = requests.get(url)
     data = response.json()
     return data['loc']
+
+
+def get_uuids_from_cache(folder_path):
+    # Get all json files from folder.
+    cache_data = glob(os.path.join(folder_path, '*.json'))
+
+    # Remove file format.
+    cache_uuids = [c.split('.json')[0] for c in cache_data]
+
+    # Remove absolute path.
+    cache_uuids = [c.split('/')[-1] for c in cache_uuids]
+
+    return cache_uuids
+
+
+def get_data_from_s3(uuid, modified):
+    s3 = S3Data()
+
+    # Make a request to get the campaign json and geojson.
+    campaign_json = s3.fetch('campaigns/{0}/campaign.json'.format(uuid))
+    geojson = s3.fetch('campaigns/{0}/campaign.geojson'.format(uuid))
+    campaign_json['geojson'] = geojson
+    campaign_json['modified'] = modified
+
+    return campaign_json
+
+
+def get_data(campaign, cache, folder_path):
+    uuid = campaign['uuid']
+    if uuid in cache:
+        # Read information from campaign.
+        uuid_path = os.path.join(folder_path, '{0}.json'.format(uuid))
+        with open(uuid_path, 'r') as f:
+            data = json.load(f)
+
+        # Check if the campaign has not been modified.
+        if (campaign['modified'] - data['modified']) == 0:
+            return data
+
+    data = get_data_from_s3(uuid, campaign['modified'])
+
+    # Save result in the cache directory.
+    file_path = os.path.join(folder_path, '{0}.json'.format(uuid))
+    with open(file_path, 'w') as f:
+        json.dump(data, f)
+
+    return data


### PR DESCRIPTION
This Pull request consists on the retrieval of campaigns data and metadata from a storage cache folder. 

**Problem statement**

Every time a user loads the index page, for every campaign, a request is performed to get the campaign.json and campaign.geojson files. These filea are read from s3. Therefore, this process takes a lot of time reading and loading the information with ajax requests.

**Proposed approach**

- Instead of executing this task every time the page is loaded, the application stores the information within a cache folder. The path corresponds to the **CACHE_DIR** and it is defined using the _osm_app_ configuration folder 
- For every uuid read from the S3 list, the server checks if the json (and geojson) file is stored. If not, the server gets the information from amazon and stores it on a file.
- There will be situations when the campaign information changes. To cope with this, the s3 list of campaigns was modified to also store the **LastModified** value from the AWS metadata. Furthermore, for a given uuid, the application will check the difference between the last modified values of the cache file and the s3 list.
- If there is a difference, it means that the campaign has been modified on the remote s3 server. So, we need to get these changes and store it on the cache directory.
- The frontend was modified to read from the server an array, whose json metadata is included on a campaign card, and geojson information put into the map.

**Notes.** 
1. Loading for the first time will take time, because the cache directory does not exists and does not contain any file.
2. We can solve the above issue making parallel processes, but I'm not sure of the hardware config yet.

