### PR TITLE
Get uuid from list of dictionaries in tests

### DIFF
--- a/flask_project/campaign_manager/test/test_s3_data.py
+++ b/flask_project/campaign_manager/test/test_s3_data.py
@@ -81,7 +81,7 @@ class TestS3Data(TestCase):
         """
         campaigns = self.s3_data.list('campaigns')
         self.assertEqual(len(campaigns), 1)
-        self.assertEqual(campaigns[0], self.uuid)
+        self.assertEqual(campaigns[0]['uuid'], self.uuid)
 
     def test_list_surveys(self):
         """


### PR DESCRIPTION
Because the returning data changed from list of uuids to list of dictionaries, we need to get the uuid field from the example dictionary on the test suite.