### PR TITLE
Force file writer to use encoding utf-8

### DIFF
--- a/flask_project/campaign_manager/utilities.py
+++ b/flask_project/campaign_manager/utilities.py
@@ -326,12 +326,6 @@ def get_data(campaign, cache, folder_path):
     return data
 
 
-def format_row(name, ctype, date, number):
-    if not isinstance(name, str):
-        name = name.encode('utf-8')
-    return '{0},{1},{2},{3}'.format(name, ctype, date, number)
-
-
 def get_contribs(url, ctype):
     req = '{0}/render/{1}/mapper_engagement.json'
     resp = requests.get(req.format(url, ctype))
@@ -343,7 +337,7 @@ def get_contribs(url, ctype):
     users = resp.json()
 
     # Create a separate list of contribution per date per user.
-    data = [[format_row(u['name'], ctype, t[0], t[1]) for t
+    data = [[[u['name'], ctype, t[0], t[1]] for t
             in json.loads(u['timeline'])] for u in users]
 
     # Flatten list.

--- a/flask_project/campaign_manager/views.py
+++ b/flask_project/campaign_manager/views.py
@@ -543,11 +543,12 @@ def generate_csv():
     file_path = os.path.join(config.CACHE_DIR, file_name)
 
     # Append headers.
-    headers = ['user,type,date,no_contribs']
-    csv_data = headers + csv_data
+    headers = ['user', 'type', 'date', 'no_contribs']
+    csv_data = [headers] + csv_data
 
-    with open(file_path, 'w') as f:
-        f.write('\n'.join(csv_data))
+    with open(file_path, 'w', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerows(csv_data)
 
     resp_dict = {'file_name': file_name, 'uuid': uuid}
 


### PR DESCRIPTION
Many campaign contributors have characters which are considered invalid due to locale configuration when writing into a file. This pull request forces the writer to use utf-8 without the need of encoding/ decoding between utf-8 and ascii.