### PR TITLE
Create campaign types and tags using a single modal instead of three

### DIFF
--- a/flask_project/campaign_manager/static/js/create/modal.js
+++ b/flask_project/campaign_manager/static/js/create/modal.js
@@ -91,7 +91,7 @@ function addCustomType(typeData) {
 
 function modalReset() {
     rowElements = {};
-    $('#custom-types-tags .modal-title').html('+ Add custom type');
+    $('#custom-types-tags .modal-title').html('+ Add type');
     $('#btn-add-custom-type').html('Add');
     $('#custom_type_name').val('');
     $('#custom_type_feature').val('');
@@ -219,6 +219,16 @@ function ReorderTags(element) {
     return cleanTags
 }
 
+function checkGeom(geometry_type, key) {
+    // Check that the given value is within the array.
+    let geometry_types = ['Point', 'Line', 'Polygon'];
+    valid_geom = geometry_types.filter(k => k === geometry_type).length;
+    if (valid_geom === 0) {
+        return '<p><b>Element type</b> field of type <b>' + key + '</b> must be <i>Point</i>, <i>Line</i> or <i>Polygon</i></p>'
+    }
+    return ''
+}
+
 function saveYamlCustomType() {
     $('.modal-required-message,.modal-error-message').hide();
 
@@ -256,7 +266,7 @@ function saveYamlCustomType() {
         }
     }
 
-    let fields = ['feature', 'tags', 'element_type'];
+    let fields = ['feature', 'tags'];
     // TODO: Include geometry checker.
     // Iterate over fields to check.
     $.each(data, function (key, value) {
@@ -265,6 +275,13 @@ function saveYamlCustomType() {
                 message += appendError(field, key);
             }
         });
+
+        // Create element type field with blank value.
+        if (!value['element_type']) {
+            value['element_type'] = '';
+        } else {
+            message += checkGeom(value['element_type'], key);
+        }
     });
     if (message !== '') {
         displayError(message); return

--- a/flask_project/campaign_manager/static/js/create/modal.js
+++ b/flask_project/campaign_manager/static/js/create/modal.js
@@ -1,0 +1,295 @@
+function addingCustomTypeForm(type_selected, element) {
+    rowElements[type_selected] = element;
+    var type = types[type_selected];
+    // init for easy format #}
+    $('#custom_type_name').val(type_selected);
+    $('#custom_type_feature').val(type['feature']);
+    $('#custom_type_element_type').val(type['element_type']);
+    $("#custom_type_feature").trigger("keyup");
+    $.each(type['tags'], function (key, value) {
+        var tag_value = key.replace(': ', '=');
+        if (value.length > 0) {
+            tag_value += '=' + value.join();
+        }
+        if (type['feature'] != tag_value) {
+            addNewCustomTags(tag_value)
+        }
+    });
+    $('#easy-format #btn-add-custom-type').html('Save');
+    $('#yaml-format #btn-add-custom-type').html('Save');
+
+    // init for yaml format #}
+    var yamlType = $.extend({}, type);
+    delete yamlType['insights'];
+    delete yamlType['custom'];
+    var tags = [];
+    $.each(yamlType['tags'], function (key, value) {
+        if (value.length == 0) {
+            var keys = key.split(': ');
+            if (keys[1]) {
+                var thisTag = {};
+                var thisTagKeys = keys[1].split(',');
+                $.each(thisTagKeys, function (index, value) {
+                    thisTagKeys[index] = $.trim(value);
+                });
+                thisTag[keys[0]] = thisTagKeys;
+                tags.push(thisTag);
+            } else {
+                tags.push(key);
+            }
+        } else {
+            var thisTag = {};
+            thisTag[key] = value;
+            tags.push(thisTag);
+        }
+    });
+    yamlType['tags'] = tags;
+    var cleanYamlType = {};
+    cleanYamlType[type_selected] = yamlType;
+    $('#yaml-input').val(
+        $('#yaml-input').val() + jsyaml.dump(cleanYamlType)
+    );
+
+    $('#modal-home').removeClass('active');
+    $('#modal-yaml').removeClass('active');
+    $('#modal-template').removeClass('active');
+
+    $('#li-template').removeClass('active').addClass('disabled');
+    $('#li-home').removeClass('active').addClass('disabled');
+    $('#li-yaml').removeClass('active');
+
+    $('#li-template a').removeAttr('data-toggle');
+    $('#li-home a').removeAttr('data-toggle');
+
+    $('#li-custom').addClass('active');
+    $('#modal-custom').addClass('active').addClass('in');
+}
+
+function switchToYamlFormat() {
+    $('#yaml-format').show();
+    $('#easy-format').hide();
+}
+
+function switchToEasyFormat() {
+    $('#yaml-format').hide();
+    $('#easy-format').show();
+}
+
+function addCustomType(typeData) {
+    types[typeData['type']] = {
+        feature: typeData['feature'],
+        insights: [
+            "FeatureAttributeCompleteness",
+            "CountFeature",
+            "MapperEngagement"
+        ],
+        tags: typeData['tags'],
+        element_type: typeData['element_type'],
+        custom: true
+    };
+}
+
+function modalReset() {
+    rowElements = {};
+    $('#custom-types-tags .modal-title').html('+ Add custom type');
+    $('#btn-add-custom-type').html('Add');
+    $('#custom_type_name').val('');
+    $('#custom_type_feature').val('');
+    $('#custom_type_element_type').val('');
+    $('#custom-tags').html('');
+    $('.modal-required-message').hide()
+    $('#yaml-input').val($('#yaml-input').html());
+    $('#switch-to-easy-format').show();
+}
+
+function addNewCustomTags(value, is_required) {
+    if (!is_required || $('#required-custom-tag-row').length == 0) {
+        var template = _.template($("#_custom_new_tag").html());
+        var html = template({
+            is_required: is_required
+        });
+        $('#custom-tags').append(html);
+        if (value) {
+            $('#custom-tags').children().last().find('input').val(value);
+        }
+    }
+    if (is_required) {
+        $('#required-custom-tag-row').find('input').val(value);
+    }
+}
+
+function removeCustomTags(element) {
+    $(element).closest('.custom-tag-row').remove();
+}
+
+function showCustomTypeRequiredMessage(element) {
+    $(element).closest('.form-group').find('.modal-required-message').show();
+}
+
+function customTypeToTypeFormat() {
+    var type_json = {
+        feature: $('#custom_type_feature').val(),
+        insights: [
+            "FeatureAttributeCompleteness",
+            "CountFeature",
+            "MapperEngagement"
+        ],
+        tags: {},
+        element_type: $('#custom_type_element_type').val(),
+        custom: true
+    };
+    $('.custom-tag-input').each(function (i, tag) {
+        var vals = $(tag).val().split('=');
+        var key = vals[0];
+        if (vals[1]) {
+            type_json['tags'][key] = vals[1].split(',');
+        } else {
+            type_json['tags'][key] = [];
+        }
+    });
+    return {
+        custom_type_name: $('#custom_type_name').val(),
+        custom_type_value: type_json
+    };
+}
+
+function saveCustomType() {
+    $('.modal-required-message').hide();
+    // check name #}
+    var $name = $('#custom_type_name');
+    if (!$name.val()) {
+        showCustomTypeRequiredMessage($name);
+    }
+    // check feature #}
+    var $feature = $('#custom_type_feature');
+    if (!$feature.val()) {
+        showCustomTypeRequiredMessage($feature);
+    }
+    // check tags #}
+    if ($('.custom-tag-input').length === 0) {
+        $('#tag-requirement-message').show();
+    }
+    $('.custom-tag-input').each(function (i, tag) {
+        if (!$(tag).val()) {
+            showCustomTypeRequiredMessage(tag);
+        }
+    });
+    var $element_type = $('#custom_type_feature');
+    // save if there is no error #}
+    if ($('.modal-required-message:visible').length === 0) {
+        var customType = customTypeToTypeFormat();
+        var name = customType['custom_type_name'];
+        var value = customType['custom_type_value'];
+        if (!rowElements[name] && types[name]) {
+            $('.modal-footer .modal-required-message').show();
+        } else {
+            $(rowElements[name]).remove();
+            $('#custom-types-tags').modal('toggle');
+            types[name] = value;
+            addTypes(name)
+        }
+    }
+}
+
+function displayError(message) {
+    $('.modal-error-message').show();
+    $('.modal-error-message').html('Error: ' + message);
+}
+
+function appendError(field, key) {
+    return '<p> No <b>' + field +'</b> element as child of <b>' + key + '</b><p>'
+}
+
+function appendRepeated(key) {
+    return '<p> Type <b>' + key +'</b> already registered <p>'
+}
+
+function ReorderTags(element) {
+    let cleanTags = {};
+    $.each(element['tags'], function (index, value) {
+        if ($.type(value) === 'string') {
+            cleanTags[value] = [];
+        }
+        else {
+            let key = Object.keys(value)[0];
+            cleanTags[key] = value[key];
+        }
+    });
+
+    return cleanTags
+}
+
+function saveYamlCustomType() {
+    $('.modal-required-message,.modal-error-message').hide();
+
+    let data;
+    try {
+        data = jsyaml.load($('#yaml-input').val());
+    } catch(error) {
+        displayError(error.message); return
+    }
+    if (typeof data === 'undefined') {
+        displayError('Empty text area'); return
+    }
+    // Error message.
+    let message = '';
+
+    let rowelements_keys = Object.keys(rowElements);
+    let data_keys = Object.keys(data);
+
+    // We cannot add types when editing..
+    if (rowelements_keys.length === 1 && data_keys.length > 1) {
+        displayError("You cannot add types when editing"); return
+    }
+
+    // We need to check that types are not repeated.
+    if (rowelements_keys.length === 0) {
+        let types_keys = Object.keys(types);
+
+        // Find the intersection of both arrays.
+        data_keys = data_keys.filter(key => types_keys.includes(key));
+        data_keys.forEach(function(key){
+            message += appendRepeated(key)
+        });
+        if (message !== '') {
+            displayError(message); return
+        }
+    }
+
+    let fields = ['feature', 'tags', 'element_type'];
+    // TODO: Include geometry checker.
+    // Iterate over fields to check.
+    $.each(data, function (key, value) {
+        fields.map(function(field) {
+            if (!value[field]) {
+                message += appendError(field, key);
+            }
+        });
+    });
+    if (message !== '') {
+        displayError(message); return
+    }
+
+    // If all fields are ok, iterate over tags.
+    $.each(data, function (key, elements) {
+        cleanTags = ReorderTags(elements)
+        // Include additional fields.
+        elements['custom'] = true;
+        elements['insights'] = [
+            "FeatureAttributeCompleteness",
+            "CountFeature",
+            "MapperEngagement"
+        ];
+        elements['tags'] = cleanTags;
+    });
+
+    // include items into the DOM.
+    $.each(data, function (key, value) {
+        if (rowelements_keys.includes(key)) {
+            $(rowElements[key]).remove();
+        }
+        types[key] = value;
+        addTypes(key);
+    });
+    $('#custom-types-tags').modal('toggle');
+}

--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -122,10 +122,7 @@
                             <div id="typesTagsContainer"></div>
                             <div class="row">
                                 <div class="form-body form-group col-lg-4" style="margin-top: 10px">
-                                    <input id="btn-add" type="button" value="+ Choose a template" onclick="addTypes()">
-                                    <input id="btn-add" type="button" value="+ Add custom type" style="margin-top: 10px" data-toggle="modal" data-target="#custom-types-tags">
-                                    <input id="btn-add" type="button" value="Edit custom types in yaml"
-                                           style="margin-top: 10px" data-format="all-yaml" data-toggle="modal" data-target="#custom-types-tags">
+                                    <input id="btn-add" type="button" value="+ Add type" style="margin-top: 10px" data-toggle="modal" data-target="#custom-types-tags">
                                 </div>
                             </div>
                             <!-- Managers -->
@@ -306,7 +303,7 @@
         <input id="submit" style="display: none" name="submit" type="submit" value="SUBMIT/UPDATE" class="btn submit-button">
     </div>
     </div>
-    {% include 'modals/custom-types-and-tags.html' %}
+    {% include 'modals/modal_main.html' %}
 
 {% endblock %}
 
@@ -369,6 +366,7 @@
     <script type="text/javascript" src="/static/js/create/map.js"></script>
 
     <script type="text/javascript" src="/static/js/create/types_tags.js"></script>
+    <script type="text/javascript" src="/static/js/create/modal.js"></script>
     <script type="text/javascript" src="/static/js/create/campaign-json-handler.js"></script>
 
     <script type='text/template' id='_template-function-form'>

--- a/flask_project/campaign_manager/templates/modals/modal_form.html
+++ b/flask_project/campaign_manager/templates/modals/modal_form.html
@@ -1,0 +1,65 @@
+<br>
+<div>
+    <div>
+        <div id="modal-form">
+            <label>Type</label>
+            <div class="form-group">
+                <input id="custom_type_name" placeholder="Name" type="text" value="" class="form-control">
+                <div class="modal-required-message">This field is required</div>
+                <p class="help-block">
+                    This is name of this type. For example : Educational Facilities.
+                </p>
+            </div>
+            <div class="form-group">
+                <input id="custom_type_feature" placeholder="Feature" type="text" value="" class="form-control">
+                <div class="modal-required-message">This field is required</div>
+                <ul class="custom-help-block">
+                    <li>This is specific feature of data for this type. For example: building, amenity, etc.</li>
+                    <li>To make it more specific, add pairing key=value in here. For example: building=school or building=school,university.</li>
+                </ul>
+            </div>
+            <br>
+            <label>Geometry Type</label>
+            <div class="form-group">
+                <select id="custom_type_element_type" class="form-control">
+                    <option name=""></option>
+                    <option name="Point">Point</option>
+                    <option name="Line">Line</option>
+                    <option name="Polygon">Polygon</option>
+                </select>
+                <ul class="custom-help-block">
+                    <li>
+                        Geometry type defines the OSM elements you want to be included in your campaign.
+                    </li>
+                    <li>
+                        If no Geometry type is selected, then it will fetch Point, Line and Polygon type elements from OSM.
+                    </li>
+                    <li>
+                        Relations are not included.
+                    </li>
+                </ul>
+            </div>
+            <br />
+            <label>Tags</label>
+            <div id="tag-requirement-message" class="modal-required-message">Tag is required at least 1.</div>
+            <div id="custom-tags" class="form-group">
+            </div>
+            <div class="form-group">
+                <input id="btn-add" class="form-control" type="button" value="+ Add tag" onclick="addNewCustomTags()">
+                <ul class="custom-help-block">
+                    <li>Add new multiple tags for this type.</li>
+                    <li>Tag is the attribute that checked on the feature. For example : name. This will check "name" attribute is exist or not in the feature.</li>
+                    <li>For specific tag, add pairing key=value in here. For example: emergency=yes,no. This will check if 'yes' or 'no' is value for emergency attribute.</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="pull-right">
+            <button type="button" id="btn-add-custom-type" class="btn btn-default btn-orange" onclick="saveCustomType()">Add</button>
+            <button type="button" class="btn btn-default btn-orange" data-dismiss="modal">Close</button>
+        </div>
+    <div class="modal-required-message">This name already registered, please choose other name.</div>
+
+    </div>
+</div>

--- a/flask_project/campaign_manager/templates/modals/modal_home.html
+++ b/flask_project/campaign_manager/templates/modals/modal_home.html
@@ -1,0 +1,14 @@
+<br>
+<p>MapCampaigner provides customizable or pre-loaded templates to help
+you create the types and tags for your campaigns. Our yaml verifies the
+elements of your types</p>
+
+<p>There are three options to create types for your campaign:</p>
+
+<ol>
+	<li>Use a pre-loaded type</li>
+	<li>Fill a custom form</li>
+	<li>Use a yaml editor</li>
+</ol>
+
+<p><b>Note.</b> In the yaml editor, you can add more than one type.</p>

--- a/flask_project/campaign_manager/templates/modals/modal_main.html
+++ b/flask_project/campaign_manager/templates/modals/modal_main.html
@@ -1,0 +1,169 @@
+<!-- Modal -->
+<style>
+    #yaml-format {
+        display: none;
+    }
+
+    .modal-content {
+        background-color: #f7f7f7 !important;
+    }
+
+    .modal-required-message, .modal-error-message {
+        display: none;
+        color: #ac3232;
+    }
+
+    #modal-form label {
+        margin-bottom: 16px;
+    }
+
+    .custom-tag-row {
+        width: 100%;
+        margin-bottom: 10px;
+        height: 36px;
+    }
+
+    .select-types:disabled {
+        width: 90% !important;
+        float: left;
+    }
+
+    .edit-custom-type {
+        padding-left: 5px;
+        float: left;
+        padding-top: 4px;
+    }
+
+    .edit-custom-type i {
+        font-size: 20px;
+        cursor: pointer;
+    }
+
+    .custom-help-block {
+        font-size: 9.4pt;
+        padding-left: 20px;
+    }
+
+    .help {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        text-align: left;
+    }
+
+    .modal-footer .modal-required-message {
+        text-align: center;
+        margin-top: 10px;
+    }
+
+    #custom-types-tags ul li a {
+        color: black;
+    }
+
+    #custom-types-tags ul li.disabled {
+        display: none;
+    }
+
+</style>
+
+<div id="custom-types-tags" class="modal fade" role="dialog">
+    <div id="easy-format" class="modal-dialog">
+        <!-- Modal content-->
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 class="modal-title">+ Add type</h4>
+            </div>
+
+			<div class="modal-body">
+				<ul class="nav nav-tabs">
+				<li id="li-home" class="active"><a data-toggle="tab" href="#modal-home">Home</a></li>
+					<li id="li-template"><a data-toggle="tab"  href="#modal-template">Choose from template</a></li>
+					<li id="li-custom"><a data-toggle="tab"  href="#modal-custom">Custom Form</a></li>
+					<li id="li-yaml"><a data-toggle="tab"  href="#modal-yaml">Yaml editor</a></li>
+				</ul>
+
+				<div class="tab-content">
+                    <div id="modal-home" class="tab-pane fade in active">
+    					{% include 'modals/modal_home.html' %}
+                    </div>
+    				<div id="modal-template" class="tab-pane fade">
+    				</div>
+    				<div id="modal-custom" class="tab-pane fade">
+    					{% include 'modals/modal_form.html' %}
+    				</div>
+    				<div id="modal-yaml" class="tab-pane fade">
+    					{% include 'modals/modal_yaml.html' %}
+    				</div>
+				</div>
+			</div>				
+        </div>
+    </div>
+</div>
+
+<script type='text/template' id='_custom_new_tag'>
+    <% if (!is_required) { %>
+    <div class="custom-tag-row">
+        <% }else{ %>
+        <div class="custom-tag-row" id="required-custom-tag-row">
+            <% } %>
+            <div class="col-lg-10">
+                <div class="form-group">
+                    <% if (!is_required) { %>
+                    <input placeholder="New tag" type="text" class="custom-tag-input form-control">
+                    <% }else{ %>
+                    <input placeholder="New tag" type="text" class="custom-tag-input form-control" disabled>
+                    <% } %>
+                    <div class="modal-required-message">This field is required</div>
+                </div>
+            </div>
+            <% if (!is_required) { %>
+            <div class="col-lg-2">
+                <button class="btn btn-warning btn-sm btn-block" style="margin-top: 1px" type="button" onclick="removeCustomTags(this)"><i class="fa fa-minus"></i></button>
+            </div>
+            <% } %>
+        </div>
+</script>
+
+<script>
+    var rowElements = {};
+    $('#custom-types-tags').on('show.bs.modal', function (e) {
+        // Add classes and attributes.
+        $('#modal-home').addClass('active').addClass('in');
+        $('#li-home').addClass('active');
+
+        $('#li-custom').removeClass('active');
+        $('#modal-custom').removeClass('active').removeClass('in');
+
+        $('#li-yaml').removeClass('active');
+        $('#modal-yaml').removeClass('active').removeClass('in');
+
+        $('#li-template').removeClass('active');
+        $('#modal-template').removeClass('active').removeClass('in').empty();
+
+        $('#li-template').removeClass('disabled');
+        $('#li-home').removeClass('disabled');
+        $('#li-yaml').removeClass('disabled');
+
+        $('#li-template a').attr('data-toggle', 'tab');
+        $('#li-home a').attr('data-toggle', 'tab');
+        $('#li-yaml a').attr('data-toggle', 'tab');
+
+        rowElements = null;
+        var relatedTarget = e.relatedTarget;
+        var type_selected = $(relatedTarget).closest('.form-group').find('select').val();
+        modalReset();
+        if (type_selected) {
+            $('#yaml-input').val('');
+            addingCustomTypeForm(type_selected, $(relatedTarget).closest('.row'))
+            $('#custom-types-tags .modal-title').html('Edit custom type of ' + type_selected);
+        }
+    });
+
+    // Check types option.
+    $('#li-template').click(function() {
+        addTypes();
+        $('#custom-types-tags').modal('toggle');
+    });
+
+</script>
+

--- a/flask_project/campaign_manager/templates/modals/modal_yaml.html
+++ b/flask_project/campaign_manager/templates/modals/modal_yaml.html
@@ -1,0 +1,54 @@
+<!-- Modal content-->
+<div>
+    <textarea id="yaml-input" rows="10" placeholder="put yaml types in here" type="text" class="form-control"></textarea>
+</div>
+<div class="modal-required-message">This field is required</div>
+<div class="modal-error-message"></div>
+<div class="help-block">
+    Edit templates in yaml above.
+</div><br>
+
+<div class="row">
+<div class="pull-right">
+    <button type="button" id="btn-add-custom-type" class="btn btn-default btn-orange" onclick="saveYamlCustomType()">Add</button>
+    <button type="button" class="btn btn-default btn-orange" data-dismiss="modal">Close</button>
+</div>
+</div>
+
+<div class="modal-required-message">Some names already registered, please choose other name.</div>
+
+<div class="help">
+    <b>GUIDE :</b>
+    <pre class="example">
+restaurant:
+    feature: amenity
+    tags:
+        - amenity:
+            - restaurant
+            - fast-food
+        - name
+        - cuisine
+    element_type: Point
+shop:
+    feature: amenity
+    tags:
+        - amenity:
+            - shop
+            - name
+        - opening_hours
+    element_type: Polygon
+        </pre>
+    Put types in yaml format. The formats are:<br>
+    - Whitespace is sensitive. Each child element must be indented below its parent element.<br>
+    - The first parent, put <b>title</b> of custom type.<br>
+    - The second one 2 key, which are feature and tags.<br>
+    - <b>Feature</b> : This is specific feature of data for this type. For example: building, amenity, etc.<br>
+    - To make it more specific, add pairing key=value in here. For example: building=school or building=school,university.<br>
+    - <b>Tags</b> : The format is the list, put dash for every line.
+    - Tag is the attribute that checked on the feature. For example : name. This will check "name" attribute is exist or not in the feature.
+    - For specific tag, add new child for that tags (for example amenity). It will check attributes is restaurant or fast-food.
+    - Can put second type (or more) by creating new parent<br />
+    - <b>Element type</b>: Point, Line, Polygon
+</div>
+
+


### PR DESCRIPTION
This pull request makes visualization changes on the create campaign view. Instead of having three different buttons to add campaign types using different modals, users are now able to click a single button to add types and tags within a single modal view. The options are:
- Using a template.
- Fill a custom form.
- Use a yaml editor.
The yaml editor includes a syntax checker and categories checker. The users must include **feature,** **tags** and **element_type** fields for each type.
![first](https://user-images.githubusercontent.com/3285923/54499255-a2ee2880-48dd-11e9-9ce4-20b6af5f8a60.gif)

With the yaml editor, users can include more than one campaign type.
![second](https://user-images.githubusercontent.com/3285923/54499260-aa153680-48dd-11e9-9d14-23c40bb8ea0d.gif)

When editing a campaign type, a modal will be displayed with two views. Users can modify the campaign type and tag using a yaml editor or the custom form.
![third](https://user-images.githubusercontent.com/3285923/54499261-b600f880-48dd-11e9-9bbd-e9f0bbb0000e.gif)

**Notes.** 
- The duplicate campaign type when editing is not fixed on this PR.
- The UI fix for edit button is not fixed on this PR.


