### PR TITLE
Read s3 path from context dictionary on map.html rendering

### DIFF
--- a/lambda_functions/render/feature/templates/map.html
+++ b/lambda_functions/render/feature/templates/map.html
@@ -9,8 +9,7 @@
   </div>
 </div>
 <script>
-  var s3_base_url = "https://s3-us-west-2.amazonaws.com/hotosm-fieldcampaigner-data-staging/campaigns/";
-  var vt_url =  s3_base_url + "{{ uuid }}" + "/render/" + "{{ type_id }}" + "/tiles/{z}/{x}/{y}.pbf";
+  var vt_url =  "{{ url }}" + "/tiles/{z}/{x}/{y}.pbf";
   mapboxgl.accessToken = 'pk.eyJ1Ijoid2lsbGUiLCJhIjoicFNVWk5VWSJ9.hluCd0YGvYHNlFi_utWe2g';
   map = new mapboxgl.Map({
     container: 'campaign-map-detail',


### PR DESCRIPTION
Instead of hardcoding the s3 url, the path is read from context dictionary sent on map.html generation