### PR TITLE
switch to new overpass url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - SECRET_KEY='tT\xd7\xb06\xf7\x9b\xff\x0fZL\xca\xca\x11\xefM\xacr\xfb\xdf\xca\x9b'
     - APP_SETTINGS=app_config.AWSTestingConfig
     - ATTIC_DATA_SERVER_URL='http://overpass-api.de/api/interpreter'
-    - DEFAULT_OVERPASS_URL='http://exports-prod.hotosm.org:6080/api/interpreter'
+    - DEFAULT_OVERPASS_URL='http://overpass.hotosm.org/api/interpreter'
 
 matrix:
   fast_finish: true

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -34,7 +34,7 @@ services:
         - DATABASE_URL=postgresql://db/gis
         - DATA_FOLDER=/home/web/field-campaigner-data
         - ATTIC_DATA_SERVER_URL=http://ec2-54-172-198-122.compute-1.amazonaws.com/api/interpreter
-        - DEFAULT_OVERPASS_URL=http://exports-prod.hotosm.org:6080/api/interpreter
+        - DEFAULT_OVERPASS_URL=http://overpass.hotosm.org/api/interpreter
       ports:
         - "64000:8080"
       volumes:
@@ -59,7 +59,7 @@ services:
         - DATABASE_URL=postgresql://db/gis
         - DATA_FOLDER=/home/web/field-campaigner-data
         - ATTIC_DATA_SERVER_URL=http://overpass-api.de/api/interpreter
-        - DEFAULT_OVERPASS_URL=http://exports-prod.hotosm.org:6080/api/interpreter
+        - DEFAULT_OVERPASS_URL=http://overpass.hotosm.org/api/interpreter
       ports:
         - "64002:5000"
       volumes:
@@ -80,7 +80,7 @@ services:
         - DATABASE_URL=postgresql://db/gis
         - DATA_FOLDER=/home/web/field-campaigner-data
         - ATTIC_DATA_SERVER_URL=http://overpass-api.de/api/interpreter
-        - DEFAULT_OVERPASS_URL=http://exports-prod.hotosm.org:6080/api/interpreter
+        - DEFAULT_OVERPASS_URL=http://overpass.hotosm.org/api/interpreter
       ports:
         - "64001:8080"
       volumes:

--- a/flask_project/campaign_manager/views.py
+++ b/flask_project/campaign_manager/views.py
@@ -496,7 +496,7 @@ def generate_josm():
     if not error_features:
         abort(404)
 
-    server_url = 'http://exports-prod.hotosm.org:6080/api/' \
+    server_url = 'http://overpass.hotosm.org/api/' \
                  'interpreter'
     error_features = json.loads(error_features)
     element_query = OverpassProvider().parse_url_parameters(

--- a/lambda_functions/download/attic_data/utilities.py
+++ b/lambda_functions/download/attic_data/utilities.py
@@ -54,7 +54,7 @@ def format_query(parameters):
 def post_request(query, feature):
     data = requests.post(
         # url='http://overpass-api.de/api/interpreter',
-        url='http://exports-prod.hotosm.org:6080/api/interpreter',
+        url='http://overpass.hotosm.org/api/interpreter',
         data={'data': query},
         headers={'User-Agent': 'HotOSM'},
         stream=True)

--- a/lambda_functions/download/errors/utilities.py
+++ b/lambda_functions/download/errors/utilities.py
@@ -85,7 +85,7 @@ def build_query(uuid, type_id, elements):
 
 def post_request(query, type_id):
     data = requests.post(
-        url='http://exports-prod.hotosm.org:6080/api/interpreter',
+        url='http://overpass.hotosm.org/api/interpreter',
         data={'data': query},
         headers={'User-Agent': 'HotOSM'},
         stream=True)

--- a/lambda_functions/download/overpass_data/utilities.py
+++ b/lambda_functions/download/overpass_data/utilities.py
@@ -329,7 +329,7 @@ def template_query_with_value():
 
 def post_request(query, type_id):
     data = requests.post(
-        url='http://exports-prod.hotosm.org:6080/api/interpreter',
+        url='http://overpass.hotosm.org/api/interpreter',
         data={'data': query},
         headers={'User-Agent': 'HotOSM'},
         stream=True)


### PR DESCRIPTION
This updates all places in the code that pointed to HOT's old overpass. We've updated our overpass to be at `overpass.hotosm.org`. 