### PR TITLE
moved instance attrs to init, fixes #679

### DIFF
--- a/lambda_functions/process/feature_attribute_completeness/parser.py
+++ b/lambda_functions/process/feature_attribute_completeness/parser.py
@@ -19,6 +19,8 @@ class FeatureCompletenessParser(xml.sax.ContentHandler):
         self.features_collected = 0  # element has tags
         self.features_completed = 0  # element has no errors
         self.errors_warnings = 0
+        self.errors_to_s = ''
+        self.warnings_to_s = ''
         self.unused_nodes = {}
         self.geojson_file_manager = GeojsonFileManager(
             destination=render_data_path)
@@ -106,7 +108,6 @@ class FeatureCompletenessParser(xml.sax.ContentHandler):
 
     def check_errors_in_tags(self):
         errors = []
-        self.errors_to_s = None
         for (key, values) in self.required_tags.items():
             if key not in self.tags.keys():
                 error = '{key} not found'.format(key=key)
@@ -129,7 +130,6 @@ class FeatureCompletenessParser(xml.sax.ContentHandler):
 
     def check_warnings_in_tags(self):
         warnings = []
-        self.warnings_to_s = None
         if 'name' in self.tags:
             name = self.tags['name']
             if name.isupper():


### PR DESCRIPTION
some instance attributes were only defined in methods and had the possibility of being skipped see:

https://github.com/hotosm/MapCampaigner/blob/214448d01977891694f3defcc414713b4c307625/lambda_functions/process/feature_attribute_completeness/parser.py#L109

and 

https://github.com/hotosm/MapCampaigner/blob/214448d01977891694f3defcc414713b4c307625/lambda_functions/process/feature_attribute_completeness/parser.py#L132

This should resolve issue #679 