### PR TITLE
Use end event to parse xml elements when rebuilding osm file

### DIFF
--- a/lambda_functions/download/overpass_data/utilities.py
+++ b/lambda_functions/download/overpass_data/utilities.py
@@ -60,13 +60,13 @@ def rebuild_osm_file(file, type_id, outside_polygons):
             osm_base = elem.attrib['osm_base']
             clean_file.write(f'<meta osm_base="{osm_base}"/>')
 
-        if elem.tag == 'node' and event == 'start':
+        if elem.tag == 'node' and event == 'end':
             # write nodes
             if elem.attrib['id'] not in outside_polygons['nodes']:
                 el = ET.tostring(elem)
                 clean_file.write(el.decode("utf-8"))
 
-        if elem.tag == 'way' and event == 'start':
+        if elem.tag == 'way' and event == 'end':
             if elem.attrib['id'] not in outside_polygons['ways']:
                 el = ET.tostring(elem)
                 clean_file.write(el.decode("utf-8"))

--- a/lambda_functions/process/feature_attribute_completeness/parser.py
+++ b/lambda_functions/process/feature_attribute_completeness/parser.py
@@ -19,9 +19,6 @@ class FeatureCompletenessParser(xml.sax.ContentHandler):
         self.features_collected = 0  # element has tags
         self.features_completed = 0  # element has no errors
         self.errors_warnings = 0
-        self.errors_to_s = ''
-        self.warnings_to_s = ''
-        self.completeness_pct = 0
         self.unused_nodes = {}
         self.geojson_file_manager = GeojsonFileManager(
             destination=render_data_path)
@@ -109,6 +106,7 @@ class FeatureCompletenessParser(xml.sax.ContentHandler):
 
     def check_errors_in_tags(self):
         errors = []
+        self.errors_to_s = None
         for (key, values) in self.required_tags.items():
             if key not in self.tags.keys():
                 error = '{key} not found'.format(key=key)
@@ -131,6 +129,7 @@ class FeatureCompletenessParser(xml.sax.ContentHandler):
 
     def check_warnings_in_tags(self):
         warnings = []
+        self.warnings_to_s = None
         if 'name' in self.tags:
             name = self.tags['name']
             if name.isupper():


### PR DESCRIPTION
This PR modifies the _rebuild_osm_file_ with the goal of parsing correctly xml elements from files. You can find more information here: https://mail.python.org/pipermail/xml-sig/2005-January/010838.html