### PR TITLE
Include whitespace to not remove opening bracket within empty geojson…

### DIFF
--- a/lambda_functions/process/feature_attribute_completeness/file_manager.py
+++ b/lambda_functions/process/feature_attribute_completeness/file_manager.py
@@ -99,7 +99,7 @@ class GeojsonFileManager(FileManager):
         super(GeojsonFileManager, self).__init__(destination)
 
     def write_header(self):
-        self.fd.write('{"type": "FeatureCollection","features": [\n')
+        self.fd.write('{"type": "FeatureCollection","features": [ \n')
 
     def write_footer(self):
         self.remove_last_comma()


### PR DESCRIPTION
… file

fixes #699.

In order to test, create a campaign with an aoi without features (could be in the ocean). Then verify within the geojson file of the feature that the structure is valid. You can check in jsonlint.com