### PR TITLE
Downgrade rsa to existing version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pytz==2019.3
 PyYAML==5.1.2
 raven==6.10.0
 requests==2.22.0
-rsa==3.5.0
+rsa==3.4.2
 s3transfer==0.2.1
 Shapely==1.6.4.post2
 simplekml==1.3.1


### PR DESCRIPTION
I ran into a problem installing requirements because [rsa 3.5.0 doesn't exist](https://pypi.org/project/rsa/#history). I suggest we change rsa to version 3.4.2.