### PR TITLE
Ignore vscode and lambda artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ data
 *~
 secret.py
 .DS_STORE
+.vscode
+lambda_functions/process/make_vector_tiles/node_modules
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml


### PR DESCRIPTION
This adds `.vscode` to the `.gitignore` file so that VS code user preferences don't get committed.

I also ran into a `node_modules` directory that gets added to the tree when the lambda functions are deployed, so I added that to the `.gitignore` file too, since I don't think it should be committed.

@russbiggs What do you think?