### PR TITLE
Consolidate config vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ data
 *~
 secret.py
 .DS_STORE
+.vscode
+lambda_functions/process/make_vector_tiles/node_modules
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ data
 secret.py
 .DS_STORE
 .vscode
+.env
 lambda_functions/process/make_vector_tiles/node_modules
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   global:
     - ON_TRAVIS=true
     - SECRET_KEY='tT\xd7\xb06\xf7\x9b\xff\x0fZL\xca\xca\x11\xefM\xacr\xfb\xdf\xca\x9b'
-    - APP_SETTINGS=app_config.AWSTestingConfig
+    - APP_SETTINGS=app_config.Config
     - ATTIC_DATA_SERVER_URL='http://overpass-api.de/api/interpreter'
     - DEFAULT_OVERPASS_URL='http://overpass.hotosm.org/api/interpreter'
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ The OSM user identity is used in this project. All actions are performed as such
             </CORSRule>
             </CORSConfiguration>
 
-    3. In flask_project/app_config.py, in DevelopmentConfig, add your bucket name.
     4. Upload folders (in bucket) "surveys", "campaigns" and "thumbnail" at the root of your project. Your S3 structure should look like:
 
             campaigns/
@@ -74,13 +73,7 @@ The OSM user identity is used in this project. All actions are performed as such
 
         $> pip install -r requirements.txt
 
-10. Create a file: flask_project/secret.py
-
-        SECRET_KEY = 'YOUR_SECRET_KEY'
-        OAUTH_CONSUMER_KEY = 'YOUR_OAUTH_CONSUMER_KEY'
-        OAUTH_SECRET = 'YOUR_OAUTH_SECRET'
-
-11. Go to the AWS Console > IAM console > Create a policy
+10. Go to the AWS Console > IAM console > Create a policy
 
         {
             "Version": "2012-10-17",
@@ -103,7 +96,7 @@ The OSM user identity is used in this project. All actions are performed as such
             ]
         }
 
-12. Stay in the IAM console > Create a Role
+11. Stay in the IAM console > Create a Role
     1. Service that will use this role: Lambda
     2. Policies:
         1. the one you just created
@@ -113,32 +106,44 @@ The OSM user identity is used in this project. All actions are performed as such
     3. Role name: whatever name you like
     4. Role description: role to execute MapCampaigner lambda functions
     5. Keep the role ARN (arn:aws:iam:::.....)
-13. Edit ./travis/deploy_lambda_functions.py
 
-        CONFIG = {
-            'local': {
-                'env': {
-                    's3_bucket': 'YOUR_BUCKET',
-                    'env': 'local'
-                },
-                'role': 'YOUR_ROLE_IN_ARN_FORMAT'
-            },
-        		...
+12. Create a file: `.env` in the project root with the following:
 
-14. Download and install Docker
-15. Deploy the lambda functions
+        # Project Config
+        ENV=local
+        PYTHONPATH=flask_project
+        DEVELOPMENT=True
+        DEBUG=True
+        # TESTING=True
+        DATA_FOLDER=/home/web/field-campaigner-data
+        CSRF_ENABLED=True
+        # AWS Config
+        SECRET_KEY=<secret key from step 6>
+        AWS_BUCKET=<AWS bucket name from step 5>
+        AWS_REGION=<AWS region name from step 5>
+        AWS_ROLE=<AWS role in arn format from step 11>
+        # OpenStreetMap Config
+        OAUTH_CONSUMER_KEY=<Oauth consumer key from step 3>
+        OAUTH_SECRET=<Oauth secret from step 3>
+        _OSMCHA_DOMAIN=https://osmcha.mapbox.com/
+        OSMCHA_API_PATH=api/v1/
+        OSMCHA_FRONTEND_URL=https://osmcha.mapbox.com/
+
+
+13. Download and install Docker
+14. Deploy the lambda functions
 
         $> python ./.travis/deploy_lambda_functions.py
 
-16. Run the server:
+15. Run the server:
 
         $> python flask_project/runserver.py
 
-17. Open your browser and visit localhost:5000
-18. Log in
+16. Open your browser and visit localhost:5000
+17. Log in
     1. It should open an OpenStreetMap popup
     2. If not, then you didn't set up properly OAUTH_CONSUMER_KEY and OAUTH_SECRET
-19. Create a campaign
+18. Create a campaign
 
 ### User Interface
 

--- a/deployment/docker-compose-hot.yml
+++ b/deployment/docker-compose-hot.yml
@@ -30,7 +30,7 @@ services:
         - PGUSER=docker
         - PGPASSWORD=docker
         - PGHOST=db
-        - APP_SETTINGS=app_config.ProductionConfig
+        - APP_SETTINGS=app_config.Config
         - DATABASE_URL=postgresql://db/gis
         - DATA_FOLDER=/home/web/field-campaigner-data
         - ATTIC_DATA_SERVER_URL=http://export.hotosm.org:6080/api/interpreter

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -30,7 +30,7 @@ services:
         - PGUSER=docker
         - PGPASSWORD=docker
         - PGHOST=db
-        - APP_SETTINGS=app_config.ProductionConfig
+        - APP_SETTINGS=app_config.Config
         - DATABASE_URL=postgresql://db/gis
         - DATA_FOLDER=/home/web/field-campaigner-data
         - ATTIC_DATA_SERVER_URL=http://ec2-54-172-198-122.compute-1.amazonaws.com/api/interpreter
@@ -55,7 +55,7 @@ services:
         - PGUSER=docker
         - PGPASSWORD=docker
         - PGHOST=db
-        - APP_SETTINGS=app_config.DevelopmentConfig
+        - APP_SETTINGS=app_config.Config
         - DATABASE_URL=postgresql://db/gis
         - DATA_FOLDER=/home/web/field-campaigner-data
         - ATTIC_DATA_SERVER_URL=http://overpass-api.de/api/interpreter
@@ -76,7 +76,7 @@ services:
         - PGUSER=docker
         - PGPASSWORD=docker
         - PGHOST=db
-        - APP_SETTINGS=app_config.DevelopmentConfig
+        - APP_SETTINGS=app_config.Config
         - DATABASE_URL=postgresql://db/gis
         - DATA_FOLDER=/home/web/field-campaigner-data
         - ATTIC_DATA_SERVER_URL=http://overpass-api.de/api/interpreter

--- a/flask_project/app.py
+++ b/flask_project/app.py
@@ -11,9 +11,9 @@ try:
 
     print('config %s ' % osm_app.config['DEBUG'])
 except KeyError:
-    from app_config import DevelopmentConfig
+    from app_config import Config
 
-    osm_app.config.from_object(DevelopmentConfig)
+    osm_app.config.from_object(Config)
 
 
 @osm_app.errorhandler(404)

--- a/flask_project/app_config.py
+++ b/flask_project/app_config.py
@@ -1,92 +1,27 @@
 import os
+from dotenv import load_dotenv
+from pathlib import Path
+env_path = Path('.') / '.env'
+load_dotenv(dotenv_path=env_path)
 
-# import SECRET_KEY into current namespace
-# noinspection PyUnresolvedReferences
-try:
-    from secret import SECRET_KEY as THE_SECRET_KEY  # noqa
-except ImportError:
-    THE_SECRET_KEY = os.environ['SECRET_KEY']
-try:
-    DATA_FOLDER = os.environ['DATA_FOLDER']
-except KeyError:
-    DATA_FOLDER = '/home/web/field-campaigner-data'
+DATA_FOLDER = os.environ.get('DATA_FOLDER', '/home/web/field-campaigner-data')
 
 
 class Config(object):
     """Configuration environment for application.
     """
-    DEBUG = False
-    TESTING = False
-    CSRF_ENABLED = True
-    SECRET_KEY = THE_SECRET_KEY
+    SECRET_KEY = os.environ.get('SECRET_KEY', '')
+    DEBUG = os.environ.get('DEBUG', False)
+    TESTING = os.environ.get('TESTING', False)
+    CSRF_ENABLED = os.environ.get('CSRF_ENABLED', False)
 
     # OSMCHA ATTRIBUTES
-    _OSMCHA_DOMAIN = 'https://osmcha.mapbox.com/'
-    OSMCHA_API = _OSMCHA_DOMAIN + 'api/v1/'
-    OSMCHA_FRONTEND_URL = 'https://osmcha.mapbox.com/'
+    _OSMCHA_DOMAIN = os.environ.get('_OSMCHA_DOMAIN', '')
+    OSMCHA_API = _OSMCHA_DOMAIN + os.environ.get('OSMCHA_API_PATH', '')
+    OSMCHA_FRONTEND_URL = os.environ.get('OSMCHA_FRONTEND_URL', '')
+
+    AWS_BUCKET = os.environ.get('AWS_BUCKET', '')
+    ENV = os.environ.get('ENV', '')
 
     # CAMPAIGN DATA
     campaigner_data_folder = DATA_FOLDER
-
-
-class ProductionConfig(Config):
-    """Production environment.
-    """
-    DEBUG = False
-    AWS_BUCKET = "fieldcampaigner-data-production"
-    ENV = "production"
-
-
-class AWSProductionConfig(Config):
-    """
-    AWS Production environment in HOTOSM AWS account.
-    """
-    DEBUG = False
-    AWS_BUCKET = "hotosm-fieldcampaigner-data-production"
-    ENV = "production"
-
-
-class StagingConfig(Config):
-    """Staging environment.
-    """
-    DEVELOPMENT = True
-    DEBUG = True
-    AWS_BUCKET = "fieldcampaigner-data-staging"
-    ENV = "staging"
-
-
-class AWSStagingConfig(Config):
-    """
-    AWS Staging environment in HOTOSM AWS account.
-    """
-    DEVELOPMENT = True
-    DEBUG = True
-    AWS_BUCKET = "hotosm-fieldcampaigner-data-staging"
-    ENV = "staging"
-
-
-class DevelopmentConfig(Config):
-    """Development environment.
-    """
-    DEVELOPMENT = True
-    DEBUG = True
-    AWS_BUCKET = "fieldcampaigner-data"
-    ENV = "local"
-
-
-class TestingConfig(Config):
-    """
-    Testing environment.
-    """
-    TESTING = True
-    DEBUG = True
-    AWS_BUCKET = 'fieldcampaigner-data-test'
-
-
-class AWSTestingConfig(Config):
-    """
-    AWS Testing environment in HOTOSM AWS account.
-    """
-    TESTING = True
-    DEBUG = True
-    AWS_BUCKET = 'hotosm-fieldcampaigner-data-test'

--- a/flask_project/campaign_manager/views.py
+++ b/flask_project/campaign_manager/views.py
@@ -55,14 +55,11 @@ from campaign_manager.aws import S3Data
 from xml.sax.saxutils import escape
 
 try:
-    from secret import OAUTH_CONSUMER_KEY, OAUTH_SECRET
-except ImportError:
-    try:
-        OAUTH_CONSUMER_KEY = os.environ['OAUTH_CONSUMER_KEY']
-        OAUTH_SECRET = os.environ['OAUTH_SECRET']
-    except KeyError:
-        OAUTH_CONSUMER_KEY = ''
-        OAUTH_SECRET = ''
+    OAUTH_CONSUMER_KEY = os.environ['OAUTH_CONSUMER_KEY']
+    OAUTH_SECRET = os.environ['OAUTH_SECRET']
+except KeyError:
+    OAUTH_CONSUMER_KEY = ''
+    OAUTH_SECRET = ''
 
 MAX_AREA_SIZE = 320000000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pyasn1==0.4.7
 PyGeoj==1.0.0
 pyparsing==2.4.2
 python-dateutil==2.8.0
+python-dotenv==0.10.3
 pytz==2019.3
 PyYAML==5.1.2
 raven==6.10.0


### PR DESCRIPTION
This is a proof of concept for moving all app configuration variables into `.env` which would allow us to develop locally with clean environments keeping all of the environment configuration in one place. (As I suggested in #745)

I put this together quickly, and while it works locally, I may have overlooked some common scenarios and I haven't tested in any environment other than local. So it definitely needs review and testing.