### PR TITLE
update osmcha url, switch cursor, map attribution & feature type card link

### DIFF
--- a/flask_project/app_config.py
+++ b/flask_project/app_config.py
@@ -21,9 +21,9 @@ class Config(object):
     SECRET_KEY = THE_SECRET_KEY
 
     # OSMCHA ATTRIBUTES
-    _OSMCHA_DOMAIN = 'https://osmcha.mapbox.com/'
+    _OSMCHA_DOMAIN = 'https://osmcha.org/'
     OSMCHA_API = _OSMCHA_DOMAIN + 'api/v1/'
-    OSMCHA_FRONTEND_URL = 'https://osmcha.mapbox.com/'
+    OSMCHA_FRONTEND_URL = 'https://osmcha.org/'
 
     # CAMPAIGN DATA
     campaigner_data_folder = DATA_FOLDER

--- a/flask_project/campaign_manager/styles/components/_buttons.scss
+++ b/flask_project/campaign_manager/styles/components/_buttons.scss
@@ -94,19 +94,22 @@
     display: none;
   }
   &:before {
+    cursor: pointer;
     content: '';
     height: 20px;
     width: 40px;
-    background: $blue-light; 
+    background: $blue-light;
     position: absolute;
     top: 0;
     right: 0;
     border-radius: 10px;
   }
   &.active:before {
+    cursor: pointer;
     background: $red;
   }
   &:after {
+    cursor: pointer;
     border-radius: 50%;
     content: '';
     height: 16px;
@@ -117,6 +120,7 @@
     right: 22px;
   }
   &.active:after {
+    cursor: pointer;
     right: 2px;
     left: auto;
   }

--- a/flask_project/campaign_manager/styles/pages/_campaigns.scss
+++ b/flask_project/campaign_manager/styles/pages/_campaigns.scss
@@ -20,9 +20,6 @@
   .row {
     .toggle-switch {
       margin-bottom: 15px;
-      @include respond-above(md) {
-        margin-right: 135px;
-      }
     }
     .form-control-wrapper {
       width: 100%;

--- a/flask_project/campaign_manager/styles/templates/_header.scss
+++ b/flask_project/campaign_manager/styles/templates/_header.scss
@@ -1,12 +1,12 @@
 .panel-pagetop, .navbar-default {
   font-family: 'Barlow Condensed', sans-serif;
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 500;
   @include respond-above(md) {
     .container {
       margin: 0;
       width: 100%;
-    }  
+    }
   }
 }
 
@@ -22,7 +22,7 @@
     margin-left: 5px;
   }
   .panel-body {
-    padding: 13px 0;
+    padding: 12px 0;
     vertical-align: middle;
   }
 }

--- a/flask_project/campaign_manager/templates/campaign_detail/map.html
+++ b/flask_project/campaign_manager/templates/campaign_detail/map.html
@@ -15,8 +15,10 @@
     container: 'campaign-map-detail',
     style: 'mapbox://styles/mapbox/light-v10',
     center: [0, 0],
-    zoom: 1
+    zoom: 1,
+    attributionControl: false
   });
+  map.addControl(new mapboxgl.AttributionControl({ compact: false }));
   map.addControl(new mapboxgl.NavigationControl());
 
   map.on('load', function() {

--- a/flask_project/campaign_manager/templates/campaign_features.html
+++ b/flask_project/campaign_manager/templates/campaign_features.html
@@ -26,45 +26,45 @@
   <div id="features-list" class="col-xs-12 col-md-6">
     <div class="row">
     {% for type in types %}
-    <div class="col-xs-12 col-md-6">
-      <div class="panel panel-tile">
-        <div class="container-fluid">
-          <div class="row">
-            <div class="col-xs-12">
-              <h4 class="panel-name">
-                {% if types[type]['element_type'] == 'Polygon' %}
-                {% include 'svgs/polygon.html' %}
-                {% elif types[type]['element_type'] == 'Point' %}
-                {% include 'svgs/point.html' %}
-                {% else %}
-                {% include 'svgs/line.html' %}
-                {% endif %}
-                {{ types[type]['type'] }}
-              </h4>
-              {% set feature_name = types[type]['type'].replace(" ", "_") %}
-              <a href="{{ url_for('campaign_manager.get_feature_details', uuid=uuid, feature_name=feature_name ) }}" class="panel-more-button">
-                {% include 'svgs/right_arrow.html' %}
-              </a>
+    <a href="{{ url_for('campaign_manager.get_feature_details', uuid=uuid, feature_name=feature_name ) }}" class="panel-more-button">
+      <div class="col-xs-12 col-md-6">
+        <div class="panel panel-tile">
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-xs-12">
+                <h4 class="panel-name">
+                  {% if types[type]['element_type'] == 'Polygon' %}
+                  {% include 'svgs/polygon.html' %}
+                  {% elif types[type]['element_type'] == 'Point' %}
+                  {% include 'svgs/point.html' %}
+                  {% else %}
+                  {% include 'svgs/line.html' %}
+                  {% endif %}
+                  {{ types[type]['type'] }}
+                </h4>
+                {% set feature_name = types[type]['type'].replace(" ", "_") %}
+                  {% include 'svgs/right_arrow.html' %}
+              </div>
             </div>
-          </div>
-          <div class="row">
-            <div class="col-xs-12">
-              <span class="panel-total-label">Total features checked</span>
-              <strong class="panel-total text-center">{{ types[type]['feature_count'] }}</strong>
+            <div class="row">
+              <div class="col-xs-12">
+                <span class="panel-total-label">Total features checked</span>
+                <strong class="panel-total text-center">{{ types[type]['feature_count'] }}</strong>
+              </div>
             </div>
-          </div>
-          <div class="row">
-            <div class="col-xs-12">
-              <p><b>{{ completeness }}%</b> <span class="panel-info">Complete Status</span> <span class="pull-right">{{ complete_status }}</span></p>
-              <div class="progress">
-                <div class="progress-bar" id="campaign-progress" role="progressbar" aria-valuenow="{{ completeness }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ completeness }}%">
+            <div class="row">
+              <div class="col-xs-12">
+                <p><b>{{ completeness }}%</b> <span class="panel-info">Complete Status</span> <span class="pull-right">{{ complete_status }}</span></p>
+                <div class="progress">
+                  <div class="progress-bar" id="campaign-progress" role="progressbar" aria-valuenow="{{ completeness }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ completeness }}%">
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </a>
     {% endfor %}
   </div>
   </div>

--- a/lambda_functions/render/feature/templates/map.html
+++ b/lambda_functions/render/feature/templates/map.html
@@ -15,8 +15,10 @@
     container: 'campaign-map-detail',
     style: 'mapbox://styles/mapbox/light-v10',
     center: [0, 0],
-    zoom: 1
+    zoom: 1,
+    attributionControl: false
   });
+  map.addControl(new mapboxgl.AttributionControl({ compact: false }));
   map.addControl(new mapboxgl.NavigationControl());
 
   map.on('load', function() {


### PR DESCRIPTION
- OSMCha url now is osmcha.org
- force map attribution to be `compact: false`
- link the entire feature type card, instead of only the red arrow
- add `cursor: pointer` to the switch toggle and remove right margin
- increase font-size on the top header. Resolves #811